### PR TITLE
Fix replace when match is "" (like when using $ or ^)

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = (str, find, replace, flags) => {
     var replaced
 
     finds.some((found, index) => {
-      if (found) {
+      if (found !== undefined) {
         if (gFlag) {
           replaced = replace[index]
         } else if (!~done.indexOf(found)) {


### PR DESCRIPTION
Fixes bug when doing something like `replaceOnce("qwerty", ["$"], ["X"], "gm")` which would lead to `"qwertyundefined"` rather than the correct value: `"qwertyX"`.